### PR TITLE
Add repository dispatch action for rebuilding instance

### DIFF
--- a/.github/workflows/deploy-to-gcr.yml
+++ b/.github/workflows/deploy-to-gcr.yml
@@ -25,3 +25,12 @@ jobs:
 
           docker compose build
           docker compose push
+
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+            token: ${{ secrets.REGISTRY_PASS }}
+            repository: v-atlas/base-ci
+            event-type: rebuild-instance
+            client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+


### PR DESCRIPTION
This pull request adds a repository dispatch action to trigger a rebuild of the instance. The action uses the `peter-evans/repository-dispatch@v2` action and is configured with the necessary parameters. This will allow for easy rebuilding of the instance when needed.